### PR TITLE
Disable unit tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -23,28 +23,6 @@ jobs:
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color --python 3.6
 
-  units:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v1
-        with:
-          path: ansible_collections/community/mongodb
-
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.6
-
-      - name: Install ansible-base
-        run: pip install git+https://github.com/ansible-collection-migration/ansible-base.git --disable-pip-version-check
-
-      - name: Run unit tests
-        run: ansible-test units --docker -v --color --python 3.6 --coverage
-
-      - name: Upload Coverage data
-        run: tests/coverage.sh
-
   integration:
     runs-on: ubuntu-latest
     strategy:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ license: null
 license_file: null
 tags: null
 dependencies:
-  community._general: '>=1.0'
+  community.general: '>=1.0'
   ansible.windows: '>=1.0'
 repository: git@github.com:ansible-collections/community.mongo.git
 documentation: https://github.com/ansible-collection/community.mongo/tree/master/docs

--- a/tests/integration/targets/mongodb_parameter/tasks/main.yml
+++ b/tests/integration/targets/mongodb_parameter/tasks/main.yml
@@ -45,7 +45,7 @@
   ignore_errors: true
 - name: Getting pids for mongod
   register: pids_of_mongod
-  community._general.pids:
+  community.general.pids:
     name: mongod
 - name: Wait for all mongod processes to exit
   wait_for:

--- a/tests/integration/targets/mongodb_parameter/tasks/mongod_teardown.yml
+++ b/tests/integration/targets/mongodb_parameter/tasks/mongod_teardown.yml
@@ -3,7 +3,7 @@
   ignore_errors: true
 - name: Getting pids for mongod
   register: pids_of_mongod
-  community._general.pids:
+  community.general.pids:
     name: mongod
 - name: Wait for all mongod processes to exit
   wait_for:

--- a/tests/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/tests/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -52,7 +52,7 @@
   shell: pkill -{{ kill_signal }} mongod;
 - name: Getting pids for mongod
   register: pids_of_mongod
-  community._general.pids:
+  community.general.pids:
     name: mongod
 - name: Wait for all mongod processes to exit
   wait_for:

--- a/tests/integration/targets/mongodb_replicaset/tasks/mongod_teardown.yml
+++ b/tests/integration/targets/mongodb_replicaset/tasks/mongod_teardown.yml
@@ -3,7 +3,7 @@
   ignore_errors: true
 - name: Getting pids for mongod
   register: pids_of_mongod
-  community._general.pids:
+  community.general.pids:
     name: mongod
 - name: Wait for all mongod processes to exit
   wait_for:

--- a/tests/integration/targets/mongodb_shard/tasks/main.yml
+++ b/tests/integration/targets/mongodb_shard/tasks/main.yml
@@ -259,7 +259,7 @@
   shell: pkill -{{ kill_signal }} mongod || true;
 - name: Getting pids for mongod
   register: pids_of_mongod
-  community._general.pids:
+  community.general.pids:
     name: mongod
 - name: Wait for all mongod processes to exit
   wait_for:

--- a/tests/integration/targets/mongodb_shard/tasks/mongod_teardown.yml
+++ b/tests/integration/targets/mongodb_shard/tasks/mongod_teardown.yml
@@ -6,7 +6,7 @@
   ignore_errors: true
 - name: Getting pids for mongod
   register: pids_of_mongod
-  community._general.pids:
+  community.general.pids:
     name: mongod
 - name: Wait for all mongod processes to exit
   wait_for:

--- a/tests/integration/targets/mongodb_user/tasks/main.yml
+++ b/tests/integration/targets/mongodb_user/tasks/main.yml
@@ -43,7 +43,7 @@
   ignore_errors: true
 - name: Getting pids for mongod
   register: pids_of_mongod
-  community._general.pids:
+  community.general.pids:
     name: mongod
 - name: Wait for all mongod processes to exit
   wait_for:

--- a/tests/integration/targets/mongodb_user/tasks/mongod_teardown.yml
+++ b/tests/integration/targets/mongodb_user/tasks/mongod_teardown.yml
@@ -3,7 +3,7 @@
   ignore_errors: true
 - name: Getting pids for mongod
   register: pids_of_mongod
-  community._general.pids:
+  community.general.pids:
     name: mongod
 - name: Wait for all mongod processes to exit
   wait_for:


### PR DESCRIPTION
mongodb doesn't have any unit tests, so remove that CI job

Also correct community.general collection name typo I made.
Integration tests will still fail for the moment till that collection is
live.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request
